### PR TITLE
Fix "Build O'Neill Cylinder" Button

### DIFF
--- a/dysonswarm.html
+++ b/dysonswarm.html
@@ -159,6 +159,13 @@
                 text-shadow: none;
             }
 
+            #clickButton.unaffordable {
+                opacity: 0.5;
+                cursor: not-allowed;
+                filter: grayscale(100%);
+                text-shadow: none;
+            }
+
         .floating-text {
             position: absolute;
             animation: floatUp 1s ease-out;
@@ -749,6 +756,16 @@
                 button.classList.add('unaffordable');
             }
         });
+
+        // The "Build O'neill Cylinder" is unique, it is a core clickButton, but unlike the other
+        // core buttons ("Sell Game", "Launch Rocket") it has a $ cost. So it needs a custom unaffordable toggle.
+        if (gameState.isSwarmCompany) {
+            if(gameState.satelliteCost > gameState.matter) { // using same check as in buildONeillCylinder()
+                clickButton.classList.add('unaffordable')
+            } else {
+                clickButton.classList.remove('unaffordable')
+            }
+        }
     }
 
 
@@ -932,11 +949,16 @@
 
     function buildONeillCylinder() {
         let matterCost = gameState.satelliteCost;
-        gameState.matter -= matterCost;
-        gameState.satellites += 1;
-        gameState.totalHumans += 200000;
-        updateCounter();
-        showFloatingText(clickButton, `-${matterCost.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}`, 'text-red-500');
+        if(matterCost > gameState.matter) {
+            showFloatingText(clickButton, "Can't afford this", 'text-red-500');
+            updateCounter();
+        } else {
+            gameState.matter -= matterCost;
+            gameState.satellites += 1;
+            gameState.totalHumans += 200000;
+            updateCounter();
+            showFloatingText(clickButton, `-${matterCost.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}`, 'text-red-500');
+        }
     }
 
     if (clickButton) {


### PR DESCRIPTION
First off, this game was wonderfully fun, I loved it!

Also, after finishing this PR I realized that this issue is most likely already documented in the readme, so if you already have a fix and want to ignore this PR and close it out, totally ok with me.

## Issue
First time I played, my game seemed to freeze at the start of the swarm stage.

Specifically it seemed like the game:
1. stopped reacting to input
2. eventually froze and crashed on the start of the swarm stage (Chrome Browser threw a `crashed tab` error, which is sometimes a memory leak?)

## Details
Tbh, I'm still not quite sure why my browser crashed (still trying to reproduce), but I did figure out that the "game is no longer reactive" issue (# 1) was most likely unrelated to `crashed tab` (# 2), and instead a UI quirk with the "Build O'Neill Cylinder" button where it looks enabled when it maybe should be disabled, at least based on how the other buttons in the game behave when the user has insufficient resources (cash, trust, etc)

After finishing this PR I realized that this line in the readme is probably referencing this issue, I should've read the manual first 🤦
> visual issue with buying cylinders in stage 4 when you don't have enough money

## TODO:
- [x] add "unaffordable" disabled toggle to "Build ONeill Cylinder" button
- [x] add "cant afford this" tooltip on click of disabled button
- [ ] figure out browser crash (memory leak?)

## Testing

### Before PR:

https://github.com/user-attachments/assets/aee2d204-35d5-49e0-8889-59c30c562a50

### After PR:

https://github.com/user-attachments/assets/63bfe000-8d67-4975-a9fc-65f459f90f8b


